### PR TITLE
Change how it calculates map distance from player

### DIFF
--- a/src/main/java/com/pveplands/treasurehunting/Treasuremap.java
+++ b/src/main/java/com/pveplands/treasurehunting/Treasuremap.java
@@ -738,7 +738,7 @@ public class Treasuremap {
      * @return True if the distance is within bounds, otherwise false.
      */
     public static boolean IsAcceptableDistance(Creature from, int toX, int toY) {
-        int distanceFromPlayer = Math.min(Math.abs(toX - from.getTileX()), Math.abs(toY - from.getTileY()));
+        int distanceFromPlayer = Math.abs(toX - from.getTileX()) + Math.abs(toY - from.getTileY());
 
         logger.info(String.format("%s distance to %d, %d is %d", from, toX, toY, distanceFromPlayer));
 

--- a/src/main/java/com/pveplands/treasurehunting/Treasuremap.java
+++ b/src/main/java/com/pveplands/treasurehunting/Treasuremap.java
@@ -738,7 +738,7 @@ public class Treasuremap {
      * @return True if the distance is within bounds, otherwise false.
      */
     public static boolean IsAcceptableDistance(Creature from, int toX, int toY) {
-        int distanceFromPlayer = Math.abs(toX - from.getTileX()) + Math.abs(toY - from.getTileY());
+        int distanceFromPlayer = (int) Math.sqrt(Math.pow(Math.abs(toX - from.getTileX()), 2) + Math.pow(Math.abs(toY - from.getTileY()), 2));
 
         logger.info(String.format("%s distance to %d, %d is %d", from, toX, toY, distanceFromPlayer));
 


### PR DESCRIPTION
Previously the smaller difference of the two coordinates was used as the distance, the possible tiles creating a plus shape as wide and high as the map. With the changes it would instead be a 45° rotated square with sides of √2*getMaxTreasureDistance().
Alternatively, changing Math.min to Math.max would make it a simple square.